### PR TITLE
Fix for test to work locally with any project_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ ddf = dask_bigquery.read_gbq(
 ddf.head()
 ```
 
+## Run tests locally
+
+To run the tests locally you need to be authenticated and have a project created on that account. If you're using a service account, when created you need to select the role of "BigQuery Admin" in the section "Grant this service account access to project". 
+
+In the directory `dask_bigquery/tests` you can run the tests by doing:
+
+`pytest --project_id your_project_id test_core.py`
+
 ## History
 
 This project stems from the discussion in

--- a/dask_bigquery/tests/conftest.py
+++ b/dask_bigquery/tests/conftest.py
@@ -1,0 +1,2 @@
+def pytest_addoption(parser):
+    parser.addoption("--project_id", action="store", default=None)

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -27,8 +27,10 @@ def df():
 
 
 @pytest.fixture
-def dataset(df):
-    project_id = os.environ.get("DASK_BIGQUERY_PROJECT_ID", "dask-bigquery")
+def dataset(pytestconfig, df):
+    project_id = os.environ.get(
+        "DASK_BIGQUERY_PROJECT_ID", pytestconfig.getoption("project_id")
+    )
     dataset_id = uuid.uuid4().hex
     table_id = "table_test"
     # push data to gbq


### PR DESCRIPTION
At the moment if someone were to want to run tests locally we are requiring to have a project with `project_id="dask-bigquery"` but as mentioned on #7 by @bnaul project_id's are unique so this wouldn't be possible. 

This PR fixes that problem and adds instructions on the readme about it. I'm not sure if this is the best way to solve this, but it's a starting point. 

cc: @jrbourbeau 

Closes #7 