### PR TITLE
Attribute google api requests to dask-bigquery package

### DIFF
--- a/dask_bigquery/__init__.py
+++ b/dask_bigquery/__init__.py
@@ -1,1 +1,3 @@
 from .core import read_gbq
+
+__version__ = "0.0.1"


### PR DESCRIPTION
- [x] Closes #6 

This PR adds a user-agent header to requests containing `dask-bigquery` name and version, as requested on issue #6. 

@tswast is there a way you suggest to test that this is working? I wasn't quite sure how to go about it. 

cc: @jrbourbeau 