### PR TITLE
Run tests locally setting env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ ddf.head()
 
 To run the tests locally you need to be authenticated and have a project created on that account. If you're using a service account, when created you need to select the role of "BigQuery Admin" in the section "Grant this service account access to project". 
 
-In the directory `dask_bigquery/tests` you can run the tests by doing:
+You can run the tests by doing:
 
-`DASK_BIGQUERY_PROJECT_ID=your_project_id pytest test_core.py`
+`$ DASK_BIGQUERY_PROJECT_ID=<your_project_id> pytest dask_bigquery`
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ ddf = dask_bigquery.read_gbq(
 ddf.head()
 ```
 
+## Run tests locally
+
+To run the tests locally you need to be authenticated and have a project created on that account. If you're using a service account, when created you need to select the role of "BigQuery Admin" in the section "Grant this service account access to project". 
+
+In the directory `dask_bigquery/tests` you can run the tests by doing:
+
+`DASK_BIGQUERY_PROJECT_ID=your_project_id pytest test_core.py`
+
 ## History
 
 This project stems from the discussion in

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -28,7 +28,7 @@ def df():
 
 @pytest.fixture
 def dataset(df):
-    project_id = os.environ.get("DASK_BIGQUERY_PROJECT_ID", "dask-bigquery")
+    project_id = os.environ.get("DASK_BIGQUERY_PROJECT_ID")
     dataset_id = uuid.uuid4().hex
     table_id = "table_test"
     # push data to gbq


### PR DESCRIPTION
This PR makes the running of tests whether it's locally or on CI use an environment variable. It is more consistent than the option suggested in #8. 

Closes #7