### PR TITLE
Add columns argument to read_gbq

### DIFF
--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from functools import partial
-from typing import List
 
 import pandas as pd
 import pyarrow
@@ -90,7 +89,7 @@ def read_gbq(
     dataset_id: str,
     table_id: str,
     row_filter: str = "",
-    columns: List[str] = None,
+    columns: list[str] = None,
     read_kwargs: dict = None,
 ):
     """Read table as dask dataframe using BigQuery Storage API via Arrow format.

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -86,6 +86,8 @@ def test_read_kwargs(dataset, client):
 
 def test_read_columns(df, dataset, client):
     project_id, dataset_id, table_id = dataset
+    assert df.shape[1] > 1, "Test data should have multiple columns"
+
     columns = ["name"]
     ddf = read_gbq(
         project_id=project_id,
@@ -93,5 +95,4 @@ def test_read_columns(df, dataset, client):
         table_id=table_id,
         columns=columns,
     )
-
     assert list(ddf.columns) == columns


### PR DESCRIPTION
Seems like a pretty important piece of functionality for a columnar database 🙂 I think maybe it just got dropped in the transition between #1 and #4? Hopefully there's not something I'm missing that makes it more complicated than it was before...

One small note, `dd.read_parquet` which seems most analogous allows a single string column name in which case you get back a `dd.Series` instead. That seemed a little too magical to me so I did not include it, if we think aligning with `dd.read_parquet` is important then it'd be easy to add.