### PR TITLE
Cleanup requirements and imports

### DIFF
--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -10,5 +10,5 @@ dependencies:
   - pytest
   - grpcio
   - pandas-gbq
-  - google-cloud-bigquery
+  - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -10,5 +10,5 @@ dependencies:
   - pytest
   - grpcio
   - pandas-gbq
-  - google-cloud-bigquery
+  - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -10,5 +10,5 @@ dependencies:
   - pytest
   - grpcio
   - pandas-gbq
-  - google-cloud-bigquery
+  - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 dask
-distributed
 google-cloud-bigquery >= 2.11.0
 google-cloud-bigquery-storage
 pandas
-pandas-gbq
 pyarrow


### PR DESCRIPTION
**Done:**
- Match version required on enviornment for CI, in the requirments we have `google-cloud-bigquery >= 2.11.0` and this wasn't set on the `enviornmetX.Y.yml` files for CI
- Remove `pandas-gbq` and `distributed` as a package requirement. We need these ones for testing but not for the package. 

**Pending/advice needed. **

- In `core.py` We are importing directly some packages from `google.api_core` This is a pacakge that get's installed when installing `google-cloud-bigquery` see [here](https://github.com/googleapis/python-bigquery/blob/66791093c61f262ea063d2a7950fc643915ee693/setup.py#L31-L36), but we thought of including it in the requriments since we import it directly. However, the `python-api-core` repor says explicitly "This library is not meant to stand-alone. Instead it defines common helpers used by all Google API clients." and this makes me a bit hesitant to set it as an actual requirement. 

- For the tests we need extra packages:
`pandas-gbq`,  `distributed`,  `google-auth-library-python` 

Do we want to include these ones here
https://github.com/coiled/dask-bigquery/blob/dee95c55b4a62ceceb8a97d61a5e86ef981f345b/setup.py#L18


like `["pytest", "pandas-gbq", 'distributed", "google-auth-library-python"]` or there is a better way of doing this?  