### PR TITLE
pin pandas-gbq to fix CI

### DIFF
--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -9,6 +9,6 @@ dependencies:
   - pyarrow
   - pytest
   - grpcio
-  - pandas-gbq
+  - pandas-gbq<=0.15
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,6 +9,6 @@ dependencies:
   - pyarrow
   - pytest
   - grpcio
-  - pandas-gbq
+  - pandas-gbq<=0.15
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,6 +9,6 @@ dependencies:
   - pyarrow
   - pytest
   - grpcio
-  - pandas-gbq
+  - pandas-gbq<=0.15
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     python_requires=">=3.7",
     install_requires=open("requirements.txt").read().strip().split("\n"),
     extras_require={
-        "test": ["pytest", "pandas-gbq", "distributed", "google-auth>=1.30.0"]
+        "test": ["pytest", "pandas-gbq<=0.15", "distributed", "google-auth>=1.30.0"]
     },
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Pinning pandas gbq to get CI green again, will work on a longer-term solution on a different PR (see #24)