### PR TITLE
Add workflow dispatch button for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: push
+on:
+  # Run manually by clicking a button in the UI
+  workflow_dispatch:
+  push:
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch

--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -9,6 +9,9 @@ dependencies:
   - pyarrow
   - pytest
   - grpcio
+  # Including grpcio-status as a temporary workaround for
+  # https://github.com/googleapis/python-api-core/issues/301
+  - grpcio-status
   - pandas-gbq<=0.15
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,6 +9,9 @@ dependencies:
   - pyarrow
   - pytest
   - grpcio
+  # Including grpcio-status as a temporary workaround for
+  # https://github.com/googleapis/python-api-core/issues/301
+  - grpcio-status
   - pandas-gbq<=0.15
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,6 +9,9 @@ dependencies:
   - pyarrow
   - pytest
   - grpcio
+  # Including grpcio-status as a temporary workaround for
+  # https://github.com/googleapis/python-api-core/issues/301
+  - grpcio-status
   - pandas-gbq<=0.15
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage


### PR DESCRIPTION
This should add a button to the GitHub actions UI for us to manually trigger CI runs on `main`