### PR TITLE
Add protobuf to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-bigquery >= 2.11.0
 google-cloud-bigquery-storage
 pandas
 pyarrow
+protobuf >= 3.17.3


### PR DESCRIPTION
Looking over at #26 and following @bnaul comment it seems that the [google-cloud-bigquery](https://github.com/googleapis/python-bigquery/blob/main/setup.py) package is asking for protobuf >= 3.12.0.

Installing dask-bigquery on an empty conda environment gives protobuf 3.17.3, but if you have protobuf set to a lower version it won't be updated. Perhaps the quick fix for #26 would be specifying protobuf >= 3.17.3 in our requirements.txt to make sure that this package will always be updated when installing dask-bigquery.

Let me know what you think  😄  