### PR TITLE
Add max_stream_count parameter to read_gbq

### DIFF
--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -114,3 +114,14 @@ def test_read_columns(df, dataset, client):
         columns=columns,
     )
     assert list(ddf.columns) == columns
+
+
+def test_max_streams(df, dataset, client):
+    project_id, dataset_id, table_id = dataset
+    ddf = read_gbq(
+        project_id=project_id,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        max_stream_count=1,
+    )
+    assert ddf.npartitions == 1


### PR DESCRIPTION
We had discussed [here](https://github.com/coiled/dask-bigquery/issues/16#issuecomment-947044542) that adding max_streams_count as a parameter might be confusing, and it seemed to me at the time that you'd probably always want as many streams as possible so why bother?

But I have a use case now where requesting too many streams is a problem: we have a microservice that loads data from BQ storage (say 10GB or so), and I'm using `dask_bigquery.read_gbq` to speed up the load using local threads. But as I scale the number of replicas of this service, I've started running into BQ storage quota issues; there's no benefit in this case to using hundreds of streams, a dozen or so would be just as good and save me from this quota headache.

It's probably an unusual situation but I think it's compelling enough that adding the argument does seem worth it after all.