### PR TITLE
Fix CI lint failure and windows CI seg fault

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -9,9 +9,9 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio=1.44
-  # Including grpcio-status as a temporary workaround for
-  # https://github.com/googleapis/python-api-core/issues/301
-  - grpcio-status
+  # - grpcio=1.44
+  # # Including grpcio-status as a temporary workaround for
+  # # https://github.com/googleapis/python-api-core/issues/301
+  # - grpcio-status
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  # - grpcio=1.44
+  - grpcio=1.44
   # # Including grpcio-status as a temporary workaround for
   # # https://github.com/googleapis/python-api-core/issues/301
   # - grpcio-status

--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio
+  - grpcio=1.44
   # Including grpcio-status as a temporary workaround for
   # https://github.com/googleapis/python-api-core/issues/301
   - grpcio-status

--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -9,9 +9,6 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio=1.44
-  # # Including grpcio-status as a temporary workaround for
-  # # https://github.com/googleapis/python-api-core/issues/301
-  # - grpcio-status
+  - grpcio<1.45
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,9 +9,9 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio=1.44
-  # Including grpcio-status as a temporary workaround for
-  # https://github.com/googleapis/python-api-core/issues/301
-  - grpcio-status
+  # - grpcio=1.44
+  # # Including grpcio-status as a temporary workaround for
+  # # https://github.com/googleapis/python-api-core/issues/301
+  # - grpcio-status
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  # - grpcio=1.44
+  - grpcio=1.44
   # # Including grpcio-status as a temporary workaround for
   # # https://github.com/googleapis/python-api-core/issues/301
   # - grpcio-status

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio
+  - grpcio=1.44
   # Including grpcio-status as a temporary workaround for
   # https://github.com/googleapis/python-api-core/issues/301
   - grpcio-status

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,9 +9,6 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio=1.44
-  # # Including grpcio-status as a temporary workaround for
-  # # https://github.com/googleapis/python-api-core/issues/301
-  # - grpcio-status
+  - grpcio<1.45
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,9 +9,9 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio=1.44
-  # Including grpcio-status as a temporary workaround for
-  # https://github.com/googleapis/python-api-core/issues/301
-  - grpcio-status
+  # - grpcio=1.44
+  # # Including grpcio-status as a temporary workaround for
+  # # https://github.com/googleapis/python-api-core/issues/301
+  # - grpcio-status
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  # - grpcio=1.44
+  - grpcio=1.44
   # # Including grpcio-status as a temporary workaround for
   # # https://github.com/googleapis/python-api-core/issues/301
   # - grpcio-status

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio
+  - grpcio=1.44
   # Including grpcio-status as a temporary workaround for
   # https://github.com/googleapis/python-api-core/issues/301
   - grpcio-status

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,9 +9,6 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - grpcio=1.44
-  # # Including grpcio-status as a temporary workaround for
-  # # https://github.com/googleapis/python-api-core/issues/301
-  # - grpcio-status
+  - grpcio<1.45
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage


### PR DESCRIPTION
It looks like `grpcio=1.45` is what is causing the segfault on Windows CI, not sure exactly what is the best procedure in views of a release. DO we need to hard ping this as a requirement? It seems it's only a problem in WIndows. 
Ideas?