### PR TITLE
Initial version of writing to_dbq via parquet in gcs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: black
       language_version: python3
       exclude: versioneer.py
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8

--- a/ci/environment-3.10.yaml
+++ b/ci/environment-3.10.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
+  - gcsfs
   - grpcio<1.45
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
+  - gcsfs
   - grpcio<1.45
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,6 +9,7 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
+  - gcsfs
   - grpcio<1.45
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/dask_bigquery/__init__.py
+++ b/dask_bigquery/__init__.py
@@ -1,3 +1,3 @@
-from .core import read_gbq
+from .core import read_gbq, to_dbq
 
 __version__ = "2022.05.0"

--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from functools import partial
 
+import datetime as dt
 import pandas as pd
 import pyarrow
 from dask.base import tokenize
@@ -11,7 +12,7 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.layers import DataFrameIOLayer
 from google.api_core import client_info as rest_client_info
 from google.api_core.gapic_v1 import client_info as grpc_client_info
-from google.cloud import bigquery, bigquery_storage
+from google.cloud import bigquery, bigquery_storage, storage
 
 import dask_bigquery
 
@@ -39,6 +40,24 @@ def bigquery_clients(project_id):
         bq_storage_client.transport.grpc_channel.close()
 
 
+@contextmanager
+def bigquery_client(project_id):
+    """Create the BugQuery Client"""
+    client_info = rest_client_info.ClientInfo(
+        user_agent=f"dask-bigquery/{dask_bigquery.__version__}"
+    )
+    with bigquery.Client(project_id, client_info=client_info) as client:
+        yield client
+
+
+def gcs_client(project_id):
+    """Create the Google Storage Client"""
+    client_info = rest_client_info.ClientInfo(
+        user_agent=f"dask-bigquery/{dask_bigquery.__version__}"
+    )
+    return storage.Client(project_id, client_info=client_info)
+
+
 def _stream_to_dfs(bqs_client, stream_name, schema, read_kwargs):
     """Given a Storage API client and a stream name, yield all dataframes."""
     return [
@@ -60,8 +79,8 @@ def bigquery_read(
 
     Parameters
     ----------
-    create_read_session_request: callable
-      kwargs to pass to `bqs_client.create_read_session` as `request`
+    make_create_read_session_request: callable
+      callable that returns input args/kwargs for `bqs_client.create_read_session`
     project_id: str
       Name of the BigQuery project.
     read_kwargs: dict
@@ -90,7 +109,8 @@ def read_gbq(
     table_id: str,
     row_filter: str = "",
     columns: list[str] = None,
-    max_stream_count: int = 0,
+    max_stream_count: int = 0,  # 0 -> use as many as BQ Storage will provide
+    preferred_min_stream_count: int = 2,
     read_kwargs: dict = None,
 ):
     """Read table as dask dataframe using BigQuery Storage API via Arrow format.
@@ -111,6 +131,12 @@ def read_gbq(
     max_stream_count: int
       Maximum number of streams to request from BQ storage; a value of 0 will request as many
       streams as possible. Note that BQ may return fewer streams than requested.
+    preferred_min_stream_count: int
+      The minimum preferred stream count. This parameter can be used to inform the service that
+      there is a desired lower bound on the number of streams. This is typically a target parallelism
+      of the client (e.g. a Spark cluster with N-workers would set this to a low multiple of N to
+      ensure good cluster utilization). The system will make a best effort to provide at least this
+      number of streams, but in some cases might provide less.
     read_kwargs: dict
       kwargs to pass to read_rows()
 
@@ -124,9 +150,8 @@ def read_gbq(
         if table_ref.table_type == "VIEW":
             raise TypeError("Table type VIEW not supported")
 
-        def make_create_read_session_request(row_filter="", max_stream_count=0):
+        def make_create_read_session_request(row_filter="", **request_kwargs):
             return bigquery_storage.types.CreateReadSessionRequest(
-                max_stream_count=max_stream_count,  # 0 -> use as many as BQ Storage will provide
                 parent=f"projects/{project_id}",
                 read_session=bigquery_storage.types.ReadSession(
                     data_format=bigquery_storage.types.DataFormat.ARROW,
@@ -135,13 +160,16 @@ def read_gbq(
                     ),
                     table=table_ref.to_bqstorage(),
                 ),
+                **request_kwargs,
             )
 
         # Create a read session in order to detect the schema.
         # Read sessions are light weight and will be auto-deleted after 24 hours.
         session = bqs_client.create_read_session(
             make_create_read_session_request(
-                row_filter=row_filter, max_stream_count=max_stream_count
+                row_filter=row_filter,
+                max_stream_count=max_stream_count,
+                preferred_min_stream_count=preferred_min_stream_count,
             )
         )
         schema = pyarrow.ipc.read_schema(
@@ -174,3 +202,73 @@ def read_gbq(
 
         graph = HighLevelGraph({output_name: layer}, {output_name: set()})
         return new_dd_object(graph, output_name, meta, divisions)
+
+
+def to_dbq(
+    df,
+    *,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    gs_bucket: str = "dask-bigquery-tmp",
+):
+    """Write dask dataframe as table using BigQuery Load API.
+    Writes Parquet to GCS for intermediary storage.
+
+    Parameters
+    ----------
+    project_id: str
+      Name of the BigQuery project id.
+    dataset_id: str
+      BigQuery dataset within project
+    table_id: str
+      BigQuery table within dataset
+    gs_bucket: str
+      Google Cloud Storage bucket name, for intermediary parquet storage. Will be created if
+      not exists. Default: dask-bigquery-tmp.
+
+    Returns
+    -------
+        LoadJobResult
+    """
+    if not project_id:
+        raise ValueError("Required: project_id")
+    if not table_id:
+        raise ValueError("Required: table_id")
+    if not dataset_id:
+        raise ValueError("Required: dataset_id")
+
+    storage_client = gcs_client(project_id)
+    bucket = storage_client.lookup_bucket(bucket_name=gs_bucket)
+    if not bucket:
+        bucket = storage_client.create_bucket(gs_bucket)
+
+    token = tokenize(df)
+    object_prefix = f"{dt.datetime.utcnow():%Y-%m-%dT%H-%M-%S}_{token}"
+
+    path = f"gs://{gs_bucket}/{object_prefix}"
+    df.to_parquet(path=path, engine="pyarrow", write_metadata_file=False)
+
+    try:
+        with bigquery_client(project_id) as client:
+            target_dataset = client.create_dataset(dataset_id, exists_ok=True)
+            target_table = target_dataset.table(table_id)
+
+            job_config = bigquery.LoadJobConfig(
+                autodetect=True,
+                source_format=bigquery.SourceFormat.PARQUET,
+                write_disposition="WRITE_EMPTY",
+            )
+            job = bigquery.Client(project_id).load_table_from_uri(
+                source_uris=f"{path}/*.parquet",
+                destination=target_table,
+                job_config=job_config,
+            )
+
+        return job.result()
+    except Exception:
+        raise
+    finally:
+        # cleanup temporary parquet
+        for blob in bucket.list_blobs(prefix=object_prefix):
+            blob.delete()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dask
+gcsfs
 google-cloud-bigquery >= 2.11.0
 google-cloud-bigquery-storage
 pandas


### PR DESCRIPTION
Implement `to_dbq` using parquet in gcs as intermediary storage. It does what people have been doing already, in a more convenient wrapper.

- [x] Closes https://github.com/coiled/dask-bigquery/issues/3