### PR TITLE
Remove pandas-gbq from extras and fix typo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,16 +8,14 @@ with open("README.md", "r", encoding="utf-8") as f:
 setup(
     name="dask-bigquery",
     version="2022.05.0",
-    description="Dask + BigQuery intergration",
+    description="Dask + BigQuery integration",
     license="BSD",
     packages=["dask_bigquery"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.8",
     install_requires=open("requirements.txt").read().strip().split("\n"),
-    extras_require={
-        "test": ["pytest", "pandas-gbq<=0.15", "distributed", "google-auth>=1.30.0"]
-    },
+    extras_require={"test": ["pytest", "distributed", "google-auth>=1.30.0"]},
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Doing some cleanup for the release, I noticed that we have an extra dependency in `setup.py` that is no longer needed, see this PR https://github.com/coiled/dask-bigquery/pull/31 . I double-check with @j-bennet and @bnaul and removing it is the right move. 

This PR removes the dependency and fixes a typo 