### PR TITLE
Change default bucket in `to_gbq`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ res = to_gbq(
 )
 ```
 
-Before loading data into BigQuery, `to_gbq` writes intermediary Parquet to a Google Storage bucket. Default bucket name is `dask-bigquery-tmp`. You can provide a diferent bucket name by setting the parameter: `bucket="my-gs-bucket"`. After the job is done, the intermediary data is deleted.
+Before loading data into BigQuery, `to_gbq` writes intermediary Parquet to a Google Storage bucket. Default bucket name is `<your_project_id>-dask-bigquery`. You can provide a diferent bucket name by setting the parameter: `bucket="my-gs-bucket"`. After the job is done, the intermediary data is deleted.
 
 If you're using a persistent bucket, we recommend configuring a retention policy that ensures the data is cleaned up even in case of job failures.
 

--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -223,7 +223,7 @@ def to_gbq(
     project_id: str,
     dataset_id: str,
     table_id: str,
-    bucket: str = "dask-bigquery-tmp",
+    bucket: str = None,
     credentials: Credentials = None,
     delete_bucket: bool = False,
     parquet_kwargs: dict = None,
@@ -242,7 +242,7 @@ def to_gbq(
       BigQuery dataset within project
     table_id: str
       BigQuery table within dataset
-    bucket: str, default: dask-bigquery-tmp
+    bucket: str, default: {project_id}-dask-bigquery
       Google Cloud Storage bucket name, for intermediary parquet storage. If the bucket doesn't
       exist, it will be created. The account you're using will need Google Cloud Storage
       permissions (storage.objects.create, storage.buckets.create). If a persistent bucket is used,
@@ -279,6 +279,9 @@ def to_gbq(
 
     # override the following kwargs, even if user specified them
     load_job_kwargs_used["source_format"] = bigquery.SourceFormat.PARQUET
+
+    if bucket is None:
+        bucket = f"{project_id}-dask-bigquery"
 
     fs = gcs_fs(project_id, credentials=credentials)
     if fs.exists(bucket):

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -185,10 +185,11 @@ def test_to_gbq_cleanup(df, write_dataset, bucket, delete_bucket):
         assert len(fs.ls(bucket, detail=False)) == 0
 
 
-def test_to_gbq_with_credentials(df, write_dataset):
+def test_to_gbq_with_credentials(df, write_dataset, monkeypatch):
     credentials, project_id, dataset_id = write_dataset
     ddf = dd.from_pandas(df, npartitions=2)
 
+    monkeypatch.delenv("GOOGLE_DEFAULT_CREDENTIALS", raising=False)
     # with explicit credentials
     result = to_gbq(
         ddf,


### PR DESCRIPTION
Prefix default bucket name with project ID, so it won't clash with existing Google Storage buckets. Bucket names have to be unique globally.

- [x] Closes https://github.com/coiled/dask-bigquery/issues/58.