### PR TITLE
Leave bucket management to the user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ res = to_gbq(
 )
 ```
 
-Before loading data into BigQuery, `to_gbq` writes intermediary Parquet to a Google Storage bucket. Default bucket name is `dask-bigquery-tmp`. You can provide a diferent bucket name by setting the parameter: `bucket="my-gs-bucket"`. After the job is done, the intermediary data is deleted.
-
-If you're using a persistent bucket, we recommend configuring a retention policy that ensures the data is cleaned up even in case of job failures.
+Before loading data into BigQuery, `to_gbq` writes intermediary Parquet to a Google Storage bucket. Bucket name should be provided, example: `bucket="my-gs-bucket"`. After the job is done, the intermediary data is deleted. We recommend configuring a retention policy for the bucket to ensure the data is cleaned up even in case of job failures.
 
 ## Run tests locally
 

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -200,8 +200,7 @@ def test_to_gbq(df, write_dataset, parquet_kwargs, load_job_kwargs):
     assert result.state == "DONE"
 
 
-@pytest.mark.parametrize("delete_bucket", [False, True])
-def test_to_gbq_cleanup(df, write_dataset, bucket, delete_bucket):
+def test_to_gbq_cleanup(df, write_dataset, bucket):
     _, project_id, dataset_id = write_dataset
     bucket, fs = bucket
 
@@ -213,15 +212,11 @@ def test_to_gbq_cleanup(df, write_dataset, bucket, delete_bucket):
         dataset_id=dataset_id,
         table_id="table_to_write",
         bucket=bucket,
-        delete_bucket=delete_bucket,
     )
     assert result.state == "DONE"
-    if delete_bucket:
-        assert not fs.exists(bucket)
-    else:
-        # bucket should be empty
-        assert fs.exists(bucket)
-        assert len(fs.ls(bucket, detail=False)) == 0
+    # bucket should be empty
+    assert fs.exists(bucket)
+    assert len(fs.ls(bucket, detail=False)) == 0
 
 
 def test_to_gbq_with_credentials(df, write_dataset):

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -20,6 +20,8 @@ from google.cloud import bigquery
 
 from dask_bigquery import read_gbq, to_gbq
 
+DASK_BIGQUERY_BUCKET = "dask-bigquery-tmp"
+
 
 @pytest.fixture(scope="module")
 def df():
@@ -196,6 +198,7 @@ def test_to_gbq(df, write_dataset, parquet_kwargs, load_job_kwargs):
         table_id="table_to_write",
         parquet_kwargs=parquet_kwargs,
         load_job_kwargs=load_job_kwargs,
+        bucket=DASK_BIGQUERY_BUCKET,
     )
     assert result.state == "DONE"
 
@@ -230,6 +233,7 @@ def test_to_gbq_with_credentials(df, write_dataset):
         dataset_id=dataset_id,
         table_id="table_to_write",
         credentials=credentials,
+        bucket=DASK_BIGQUERY_BUCKET,
     )
     assert result.state == "DONE"
 
@@ -240,7 +244,11 @@ def test_roundtrip(df, write_dataset):
     table_id = "roundtrip_table"
 
     result = to_gbq(
-        ddf, project_id=project_id, dataset_id=dataset_id, table_id=table_id
+        ddf,
+        project_id=project_id,
+        dataset_id=dataset_id,
+        table_id=table_id,
+        bucket=DASK_BIGQUERY_BUCKET,
     )
     assert result.state == "DONE"
 


### PR DESCRIPTION
No default bucket, user should create the bucket before calling `to_gbq`.

Alternative to https://github.com/coiled/dask-bigquery/pull/61.