### PR TITLE
Revert to `google.cloud.storage.Client`

### DIFF
--- a/ci/environment-3.10.yaml
+++ b/ci/environment-3.10.yaml
@@ -9,6 +9,5 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - gcsfs
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.10.yaml
+++ b/ci/environment-3.10.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pytest
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage
+  - google-cloud-storage

--- a/ci/environment-3.10.yaml
+++ b/ci/environment-3.10.yaml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.10
   - dask
   - distributed
+  - gcsfs
   - pandas
   - pyarrow
   - pytest

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.8
   - dask
   - distributed
+  - gcsfs
   - pandas
   - pyarrow
   - pytest

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -9,6 +9,5 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - gcsfs
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pytest
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage
+  - google-cloud-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -9,6 +9,5 @@ dependencies:
   - pandas
   - pyarrow
   - pytest
-  - gcsfs
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -11,3 +11,4 @@ dependencies:
   - pytest
   - google-cloud-bigquery>=2.11.0
   - google-cloud-bigquery-storage
+  - google-cloud-storage

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -6,6 +6,7 @@ dependencies:
   - python=3.9
   - dask
   - distributed
+  - gcsfs
   - pandas
   - pyarrow
   - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dask
 google-cloud-bigquery >= 2.11.0
 google-cloud-bigquery-storage
+google-cloud-storage
 pandas
 pyarrow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 dask
+gcsfs
 google-cloud-bigquery >= 2.11.0
 google-cloud-bigquery-storage
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dask
-gcsfs
 google-cloud-bigquery >= 2.11.0
 google-cloud-bigquery-storage
 pandas


### PR DESCRIPTION
Naty and I had an [issue](https://github.com/fsspec/gcsfs/issues/553) with `gcsfs` that we could not resolve, and going back to the official Google Storage client seems like a safer bet, even if it has a clunkier API. 

We'll probably still have a pickling problem once it comes to running on a cluster in the Cloud, not just a local one.