### PR TITLE
Fix passing credentials to `gcsfs`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # Needed by codecov.io
+          fetch-depth: 0 # Needed by codecov.io
 
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2
@@ -55,4 +55,5 @@ jobs:
       - name: Run tests
         env:
           DASK_BIGQUERY_PROJECT_ID: "${{ secrets.GCP_PROJECT_ID }}"
+          DASK_BIGQUERY_GCP_CREDENTIALS: "${{ secrets.GCP_CREDENTIALS }}"
         run: pytest -v dask_bigquery

--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ res = dask_bigquery.to_gbq(
 With explicit credentials:
 
 ```python
+import dask
+import dask_bigquery
 from google.oauth2.service_account import Credentials
 
-# credentials
-creds_dict = {"type": ..., "project_id": ..., "private_key_id": ...}
-credentials = Credentials.from_service_account_info(info=creds_dict)
+ddf = dask.datasets.timeseries(freq="1min")
 
-res = to_gbq(
+# credentials
+credentials = Credentials.from_service_account_file("/home/<username>/google.json")
+
+res = dask_bigquery.to_gbq(
     ddf,
     project_id="my_project_id",
     dataset_id="my_dataset_id",

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ ddf.head()
 
 ## Example: write to BigQuery
 
+### Write to BigQuery with default credentials
+
 Assuming that client and workers are already provisioned with default credentials:
 
 ```python
@@ -92,7 +94,20 @@ res = dask_bigquery.to_gbq(
 
 Before loading data into BigQuery, `to_gbq` writes intermediary Parquet to a Google Storage bucket. Default bucket name is `<your_project_id>-dask-bigquery`. You can provide a diferent bucket name by setting the parameter: `bucket="my-gs-bucket"`. After the job is done, the intermediary data is deleted.
 
-If you're using a persistent bucket, we recommend configuring a retention policy that ensures the data is cleaned up even in case of job failures.
+### Write to BigQuery with explicit (non-default) credentials
+
+```python
+# service account credentials
+creds_dict = {"type": ..., "project_id": ..., "private_key_id": ...}
+
+res = to_gbq(
+    ddf,
+    project_id="my_project_id",
+    dataset_id="my_dataset_id",
+    table_id="my_table_name",
+    credentials=credentials,
+)
+```
 
 ## Run tests locally
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ddf.head()
 
 ## Example: write to BigQuery
 
-With default credentials:
+Assuming that client and workers are already provisioned with default credentials:
 
 ```python
 import dask
@@ -87,27 +87,6 @@ res = dask_bigquery.to_gbq(
     project_id="my_project_id",
     dataset_id="my_dataset_id",
     table_id="my_table_name",
-)
-```
-
-With explicit credentials:
-
-```python
-import dask
-import dask_bigquery
-from google.oauth2.service_account import Credentials
-
-ddf = dask.datasets.timeseries(freq="1min")
-
-# credentials
-credentials = Credentials.from_service_account_file("/home/<username>/google.json")
-
-res = dask_bigquery.to_gbq(
-    ddf,
-    project_id="my_project_id",
-    dataset_id="my_dataset_id",
-    table_id="my_table_name",
-    credentials=credentials,
 )
 ```
 

--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -14,7 +14,6 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.layers import DataFrameIOLayer
 from google.api_core import client_info as rest_client_info
 from google.api_core.gapic_v1 import client_info as grpc_client_info
-from google.auth import default as google_auth_default
 from google.auth.credentials import Credentials
 from google.cloud import bigquery, bigquery_storage
 
@@ -58,9 +57,6 @@ def bigquery_client(project_id, credentials=None):
 
 def gcs_fs(project_id, credentials=None):
     """Create the GCSFS client"""
-    if credentials is None:
-        credentials, default_project_id = google_auth_default()
-        project_id = project_id or default_project_id
     return gcsfs.GCSFileSystem(
         project=project_id, access="read_write", token=credentials
     )

--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -62,7 +62,7 @@ def gcs_fs(project_id, credentials=None):
         credentials, default_project_id = google_auth_default()
         project_id = project_id or default_project_id
     return gcsfs.GCSFileSystem(
-        project=project_id, access="read_write", token=credentials.token
+        project=project_id, access="read_write", token=credentials
     )
 
 

--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -14,8 +14,10 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.layers import DataFrameIOLayer
 from google.api_core import client_info as rest_client_info
 from google.api_core.gapic_v1 import client_info as grpc_client_info
+from google.auth import default as google_auth_default
 from google.auth.credentials import Credentials
 from google.cloud import bigquery, bigquery_storage
+from google.oauth2 import service_account
 
 import dask_bigquery
 
@@ -57,6 +59,16 @@ def bigquery_client(project_id, credentials=None):
 
 def gcs_fs(project_id, credentials=None):
     """Create the GCSFS client"""
+    if credentials is None:
+        credentials, default_project_id = google_auth_default()
+        project_id = project_id or default_project_id
+
+    # if it's a service account, update scope
+    if isinstance(credentials, service_account.Credentials):
+        credentials = credentials.with_scopes(
+            ["https://www.googleapis.com/auth/devstorage.read_write"]
+        )
+
     return gcsfs.GCSFileSystem(
         project=project_id, access="read_write", token=credentials
     )

--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -15,9 +15,8 @@ from dask.layers import DataFrameIOLayer
 from google.api_core import client_info as rest_client_info
 from google.api_core.gapic_v1 import client_info as grpc_client_info
 from google.auth import default as google_auth_default
-from google.auth.credentials import Credentials
+from google.auth.credentials import Credentials, Scoped
 from google.cloud import bigquery, bigquery_storage
-from google.oauth2 import service_account
 
 import dask_bigquery
 
@@ -64,7 +63,7 @@ def gcs_fs(project_id, credentials=None):
         project_id = project_id or default_project_id
 
     # if it's a service account, update scope
-    if isinstance(credentials, service_account.Credentials):
+    if isinstance(credentials, Scoped) and credentials.requires_scopes:
         credentials = credentials.with_scopes(
             ["https://www.googleapis.com/auth/devstorage.read_write"]
         )

--- a/dask_bigquery/core.py
+++ b/dask_bigquery/core.py
@@ -251,9 +251,10 @@ def to_gbq(
       permissions (storage.objects.create, storage.buckets.create). If a persistent bucket is used,
       it is recommended to configure a retention policy that ensures the data is cleaned up in
       case of job failures.
-    credentials : google.auth.credentials.Credentials, optional
+    credentials : google.auth.credentials.Credentials | dict | str, optional
       Credentials for accessing Google APIs. Use this parameter to override
-      default credentials.
+      default credentials. gcsfs will accept the following values as credentials:
+      https://gcsfs.readthedocs.io/en/latest/index.html#credentials
     delete_bucket: bool, default: False
       Delete bucket in GCS after loading intermediary data to Big Query. The bucket will only be deleted if it
       didn't exist before.

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -50,10 +50,7 @@ def dataset():
 
         yield dataset
 
-        bq_client.delete_dataset(
-            dataset=f"{project_id}.{dataset_id}",
-            delete_contents=True,
-        )
+        bq_client.delete_dataset(dataset=dataset, delete_contents=True)
 
 
 @pytest.fixture(scope="module")
@@ -79,7 +76,7 @@ def table(dataset, df):
         )  # Make an API request.
         job.result()
 
-    yield (project_id, dataset_id, table_id)
+    yield project_id, dataset_id, table_id
 
 
 @pytest.fixture(scope="module")
@@ -109,7 +106,7 @@ def required_partition_filter_table(dataset, df):
         table.require_partition_filter = True
         bq_client.update_table(table, ["require_partition_filter"])
 
-    yield (project_id, dataset_id, table_id)
+    yield project_id, dataset_id, table_id
 
 
 @pytest.fixture

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -16,8 +16,8 @@ from distributed.utils_test import cluster_fixture  # noqa: F401
 from distributed.utils_test import loop  # noqa: F401
 from distributed.utils_test import loop_in_thread  # noqa: F401
 from google.api_core.exceptions import InvalidArgument
+from google.auth.credentials import Scoped
 from google.cloud import bigquery
-from google.oauth2 import service_account
 
 from dask_bigquery import read_gbq, to_gbq
 
@@ -122,7 +122,7 @@ def bucket():
     bucket = f"dask-bigquery-tmp-{uuid.uuid4().hex}"
 
     # if it's a service account, update scope
-    if isinstance(credentials, service_account.Credentials):
+    if isinstance(credentials, Scoped) and credentials.requires_scopes:
         credentials = credentials.with_scopes(
             ["https://www.googleapis.com/auth/devstorage.read_write"]
         )

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -113,14 +113,14 @@ def required_partition_filter_table(dataset, df):
 
 @pytest.fixture
 def bucket():
-    credentials, project_id = google.auth.default()
+    _, project_id = google.auth.default()
     env_project_id = os.environ.get("DASK_BIGQUERY_PROJECT_ID")
     if env_project_id:
         project_id = env_project_id
 
     bucket = f"dask-bigquery-tmp-{uuid.uuid4().hex}"
 
-    fs = gcsfs.GCSFileSystem(project=project_id, access="read_write", token=credentials)
+    fs = gcsfs.GCSFileSystem(project=project_id, access="read_write")
 
     yield bucket, fs
 

--- a/dask_bigquery/tests/test_core.py
+++ b/dask_bigquery/tests/test_core.py
@@ -120,9 +120,7 @@ def bucket():
 
     bucket = f"dask-bigquery-tmp-{uuid.uuid4().hex}"
 
-    fs = gcsfs.GCSFileSystem(
-        project=project_id, access="read_write", token=credentials.token
-    )
+    fs = gcsfs.GCSFileSystem(project=project_id, access="read_write", token=credentials)
 
     yield bucket, fs
 


### PR DESCRIPTION
According to the docs here:

https://gcsfs.readthedocs.io/en/latest/index.html#credentials

`gcsfs` does not accept just a token, it needs a `Credentials` instance or a dict. For dask `dict` works better, because it can be pickled.

We also pass the same credentials to `to_parquet`.