### PR TITLE
Update google auth action in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,13 +44,14 @@ jobs:
       - name: Install dask-bigquery
         run: python -m pip install --no-deps -e .
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
+      - id: auth
+        uses: google-github-actions/auth@v1
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-      
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
       - name: Run tests
         env:
           DASK_BIGQUERY_PROJECT_ID: "${{ secrets.GCP_PROJECT_ID }}"


### PR DESCRIPTION
Closes https://github.com/coiled/dask-bigquery/issues/40.

I think this is what it takes, at least according to the docs here:

https://github.com/google-github-actions/setup-gcloud#service-account-key-json

~We still need to put the `GCP_CREDENTIALS` json blob into `secrets`.~ ✅ 