### PR TITLE
Update checkout action version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0  # Needed by codecov.io
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3.5.2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Needed by codecov.io
 


### PR DESCRIPTION
The macos ci runs for py3.8 and 3.10 keep hanging. Trying out couple of things here and see what happens. 